### PR TITLE
update package name php7

### DIFF
--- a/packages-hw-i686/Dockerfile
+++ b/packages-hw-i686/Dockerfile
@@ -23,7 +23,7 @@ RUN sudo apt-get update && \
 # List of packages we build. This will eventually just be "world".
 # TODO rust: currently only supports x86_64, left out.
 # TODO erlang: does not build (see rumprun-packages issues)
-ENV BUILD_PACKAGES="mathopd hiawatha leveldb libxml2 pcre mpg123 nginx php ngircd redis mysql roundcube python3 nodejs"
+ENV BUILD_PACKAGES="mathopd hiawatha leveldb libxml2 pcre mpg123 nginx php7 ngircd redis mysql roundcube python3 nodejs"
 
 # Build the packages, using as many CPUs as available.
 RUN STDJ=$(cat /proc/cpuinfo | grep '^processor.*:' | wc -l) && \

--- a/packages-hw-x86_64/Dockerfile
+++ b/packages-hw-x86_64/Dockerfile
@@ -23,7 +23,7 @@ RUN sudo apt-get update && \
 # List of packages we build. This will eventually just be "world".
 # TODO erlang: does not build (see rumprun-packages issues)
 # TODO rust: times out build
-ENV BUILD_PACKAGES="mathopd hiawatha leveldb libxml2 pcre mpg123 nginx php ngircd redis mysql roundcube python3 nodejs"
+ENV BUILD_PACKAGES="mathopd hiawatha leveldb libxml2 pcre mpg123 nginx php7 ngircd redis mysql roundcube python3 nodejs"
 
 # Build the packages, using as many CPUs as available.
 RUN STDJ=$(cat /proc/cpuinfo | grep '^processor.*:' | wc -l) && \


### PR DESCRIPTION
The the `php` application folder in repo `https://github.com/rumpkernel/rumprun-packages` have been renamed to php5 and php7. So should update the folder name here, otherwise will got error:

```
make: *** php: No such file or directory.  Stop.
```
